### PR TITLE
Default-None-contract now working correctly

### DIFF
--- a/clock/templates/pages/quick_actions.html
+++ b/clock/templates/pages/quick_actions.html
@@ -1,4 +1,4 @@
-﻿{% load i18n %}
+﻿{% load i18n crispy_forms_tags %}
         <form id="post-form" action="{% url 'work:quick_action' %}" method="post">
             {% csrf_token %}
         {% if shift_closed and shift_paused %}
@@ -11,9 +11,8 @@
             <button class="btn btn-app" type="submit" name="_stop"><i class="fa fa-stop fa-3x"></i>{% trans "Stop" %}</button>
 
             <select class="block form-control work-select" name="contract"{% if not all_contracts %}disabled{% endif %}>
-                {% for institutes in all_contracts %}
-                <option value="{{ institutes.pk }}"{% if institutes == default_contract %} selected="selected"{% endif %}>{{ institutes }}</option>
+                {% for options in form.contract.field.choices %}
+                <option value="{{ options.0 }}"{% if options.1 == default_contract %} selected="selected"{% endif %}>{{ options.1 }}</option>
                 {% endfor %}
-                <option value="None">{% trans 'Without assignment' %}</option>
             </select>
         </form>

--- a/clock/work/forms.py
+++ b/clock/work/forms.py
@@ -14,14 +14,13 @@ class QuickActionForm(forms.Form):
     Small helper form for the selection of an institute/contract
     on the dashboard for the quick buttons.
     """
-    def __init__(self, *args, **kwargs):
-        # Pop the supplied user from the form, so we can retrieve
-        # the users signed contracts for the quick-action menu.
-        user = kwargs.pop('user')
-        super(QuickActionForm, self).__init__(*args, **kwargs)
-        self.fields['contract'].queryset = user.contract_set.all()
 
-    contract = forms.ModelChoiceField(queryset='')
+    contract = forms.ModelChoiceField(queryset = Contract.objects.none(), empty_label=_('None defined'))
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        super(QuickActionForm, self).__init__(*args, **kwargs)
+        self.fields['contract'].queryset = self.user.contract_set.all()
 
 
 class ContractForm(forms.ModelForm):

--- a/clock/work/forms.py
+++ b/clock/work/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from bootstrap3_datetime.widgets import DateTimePicker
 from crispy_forms.helper import FormHelper
@@ -15,15 +14,21 @@ class QuickActionForm(forms.Form):
     on the dashboard for the quick buttons.
     """
 
-    contract = forms.ModelChoiceField(queryset = Contract.objects.none(), empty_label=_('None defined'))
+    contract = forms.ModelChoiceField(
+        queryset=Contract.objects.none(),
+        empty_label=_('None defined')
+        )
 
     def __init__(self, *args, **kwargs):
+        # Retrieve the logged in user, that we provide inside the view
         self.user = kwargs.pop('user', None)
         super(QuickActionForm, self).__init__(*args, **kwargs)
+        # Only show the users contracts
         self.fields['contract'].queryset = self.user.contract_set.all()
 
 
 class ContractForm(forms.ModelForm):
+
     class Meta:
         model = Contract
         fields = ('department', 'department_short', 'hours',)
@@ -118,7 +123,9 @@ class ShiftForm(forms.ModelForm):
                                     shift_finished
                                 )
             if check_for_overlaps:
-                raise ValidationError(_('Your selected starting/finishing time overlaps with at least one finished shift of yours. Please adjust the times.'))
+                raise ValidationError(
+                    _('Your selected starting/finishing time overlaps with at least one\
+                     finished shift of yours. Please adjust the times.'))
 
         return cleaned_data
 
@@ -135,7 +142,7 @@ class ShiftForm(forms.ModelForm):
                                       shift_finished__gte=shift_started
                                       )
 
-        # Check if the retrieved shifts contain the shift we're trying to update. If yes, then pass.
+        # Check if the retrieved shifts contain the shift we're trying to update. If yes: pass.
         for shift in shifts:
             if shift == self.instance:
                 pass

--- a/clock/work/models.py
+++ b/clock/work/models.py
@@ -19,8 +19,8 @@ class Contract(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):
-        if self.department_short:
-            return self.department_short
+        # if self.department_short:
+        #     return self.department_short
         return self.department
 
 

--- a/clock/work/models.py
+++ b/clock/work/models.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
@@ -9,9 +8,12 @@ from django.utils.translation import ugettext_lazy as _
 
 class Contract(models.Model):
     """
-    Employees may define a contract, which they assign their finished shifts to.
+    Employees may define a contract, which is assigned to a finished shift.
     """
-    employee = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    employee = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE
+    )
     department = models.CharField(max_length=200)
     department_short = models.CharField(max_length=100, blank=True, null=True)
     hours = models.DurationField()
@@ -26,15 +28,31 @@ class Contract(models.Model):
 
 class Shift(models.Model):
     """
-    Employees start/pause/stop shifts to track their worktime. May be assigned to a contract.
+    Employees start/pause/stop shifts to track their worktime.
+    May be assigned to a contract.
     """
     employee = models.ForeignKey(settings.AUTH_USER_MODEL)
-    contract = models.ForeignKey(Contract, null=True, blank=True, on_delete=models.CASCADE)
+    contract = models.ForeignKey(
+        Contract,
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE
+    )
     shift_started = models.DateTimeField(verbose_name=_('Shift started'))
-    shift_finished = models.DateTimeField(null=True, verbose_name=_('Shift finished'))
-    shift_duration = models.DurationField(blank=True, null=True, verbose_name=_('Shift duration'))
+    shift_finished = models.DateTimeField(
+        null=True,
+        verbose_name=_('Shift finished')
+    )
+    shift_duration = models.DurationField(
+        blank=True,
+        null=True,
+        verbose_name=_('Shift duration')
+    )
     pause_started = models.DateTimeField(blank=True, null=True)
-    pause_duration = models.DurationField(default=timedelta(seconds=0), verbose_name=_('Pause duration'))
+    pause_duration = models.DurationField(
+        default=timedelta(seconds=0),
+        verbose_name=_('Pause duration')
+    )
     note = models.TextField(_('Note'), blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -49,7 +67,8 @@ class Shift(models.Model):
 
     def __init__(self, *args, **kwargs):
         """
-        Initialize the model with the old shift_started/shift_finished values, so we can compare them with the new ones in the save() method.
+        Initialize the model with the old shift_started/shift_finished values,
+        so we can compare them with the new ones in the save() method.
         """
         super(Shift, self).__init__(*args, **kwargs)
         self.__old_shift_started = self.shift_started
@@ -57,34 +76,46 @@ class Shift(models.Model):
 
     def clean(self, *args, **kwargs):
         """
-        Run the super clean() method and then run the custom validation that we need.
+        Run the super clean() method and the custom validation that we need.
         """
         super(Shift, self).clean(*args, **kwargs)
         self.shift_time_validation()
 
     def save(self, *args, **kwargs):
         """
-        If either the shift_finished or shift_started values were changed, then we'll calculate the shift_duration. Also substract the pause_duration while we're at it. This accounts for both the quick-action buttons and manual edits in the admin-backend or dashboard-frontend.
+        If either the shift_finished or shift_started values were changed,
+        then we'll calculate the shift_duration. Also substract the
+        pause_duration while we're at it. This accounts for both the
+        quick-action buttons and manual edits in the admin-backend
+        or dashboard-frontend.
         """
-        if self.shift_finished != self.__old_shift_finished or self.shift_started != self.__old_shift_started:
-            self.shift_duration = (self.shift_finished - self.shift_started) - self.pause_duration
+        if self.shift_finished != self.__old_shift_finished \
+            or self.shift_started != self.__old_shift_started:
+                self.shift_duration = (self.shift_finished -
+                self.shift_started) - self.pause_duration
         return super(Shift, self).save(*args, **kwargs)
 
     def shift_time_validation(self):
         """
-        Validation method to check for different cases of shift overlaps and other violations.
+        Validation method to check for different cases of shift overlaps
+        and other violations.
         """
         errors = {}
         if self.shift_started and self.shift_finished:
             if self.shift_started > timezone.now():
-                errors['shift_started'] = _('Your shift must not start in the future!')
+                errors['shift_started'] = _('Your shift must not start in the \
+                    future!')
             if self.shift_finished > timezone.now():
-                errors['shift_finished'] = _('Your shift must not finish in the future!')
+                errors['shift_finished'] = _('Your shift must not finish in \
+                    the future!')
             if self.shift_finished < self.shift_started:
-                errors['shift_finished'] = _('A shift must not finish, before it has even started!')
+                errors['shift_finished'] = _('A shift must not finish, before \
+                    it has even started!')
 
-            #if (self.shift_finished - self.shift_started) > timedelta(hours=6):
-            #    errors['shift_finished'] = _('Your shift may not be longer than 6 hours.')
+            # if (self.shift_finished - self.shift_started) > \
+            # timedelta(hours=6):
+            #    errors['shift_finished'] = _('Your shift may not be \
+            # longer than 6 hours.')
 
             if errors:
                 raise ValidationError(errors)

--- a/clock/work/utils.py
+++ b/clock/work/utils.py
@@ -33,10 +33,11 @@ def get_default_contract(user):
     """
 
     contracts = get_all_contracts(user)
-    finished_shifts = Shift.objects.filter(employee=user,
-                                           shift_finished__isnull=False)
+    finished_shifts = Shift.objects.filter(employee=user)
 
     if finished_shifts:
-        return finished_shifts[0].contract
+        if finished_shifts[0].contract == None:
+            return None
+        return finished_shifts[0].contract.department
 
     return contracts

--- a/clock/work/utils.py
+++ b/clock/work/utils.py
@@ -26,18 +26,21 @@ def get_all_contracts(user):
 def get_default_contract(user):
     """
     Returns the default institute of the user.
-        - If the user only has one defined, then use this.
-        - If he has more than one defined, let us look into his
-          finished shifts and use the most recent one.
-        - Otherwise use the one with the smallest ID.
+        - If the user has any finished shifts, then return the contract
+          of the last finished shift.
+        - If no shifts were finished yet, but the user has defined contracts,
+          return the contract that was added first.
+        - If no contracts are defined, then return the NoneObject as default
     """
-
-    contracts = get_all_contracts(user)
+    # Filter all shifts (finished or not) from the current user
     finished_shifts = Shift.objects.filter(employee=user)
 
+    # If the user has shifts
     if finished_shifts:
-        if finished_shifts[0].contract == None:
-            return None
-        return finished_shifts[0].contract.department
+        # Are there any shifts finished for a non-default contract?
+        if finished_shifts[0].contract is not None:
+            # Return the contract of the latest shift
+            return finished_shifts[0].contract.department
 
-    return contracts
+    # Return NoneObject for the defaukt None-contract
+    return None

--- a/clock/work/views.py
+++ b/clock/work/views.py
@@ -27,6 +27,9 @@ def home(request):
         context['default_contract'] = get_default_contract(request.user)
         template_to_render = 'pages/dashboard.html'
 
+        # Initialize the QuickActionForm
+        context['form'] = QuickActionForm(user=request.user)
+
         # Get the current shift to display the possible quick-actions.
         shift = get_current_shift(request.user.id)
 

--- a/clock/work/views.py
+++ b/clock/work/views.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse_lazy
+from django.http import Http404
 from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -54,10 +55,20 @@ def shift_action(request):
     shift = get_current_shift(request.user)
 
     if not shift and not '_start' in request.POST:
-        messages.add_message(request, messages.ERROR, _('You need an active shift to perform this action!'), 'danger')
+        messages.add_message(
+            request,
+            messages.ERROR,
+            _('You need an active shift to perform this action!'),
+            'danger'
+        )
         return redirect('home')
     elif shift and '_start' in request.POST:
-        messages.add_message(request, messages.ERROR, _('You already have an active shift!'), 'danger')
+        messages.add_message(
+            request,
+            messages.ERROR,
+            _('You already have an active shift!'),
+            'danger'
+        )
         return redirect('home')
 
     # Start a new shift
@@ -83,7 +94,11 @@ def shift_action(request):
                                         )
 
         # Show a success message
-        messages.add_message(request, messages.SUCCESS, _('Your shift has started!'))
+        messages.add_message(
+            request,
+            messages.SUCCESS,
+            _('Your shift has started!')
+        )
 
     # Stop current shift
     elif '_stop' in request.POST:
@@ -94,7 +109,11 @@ def shift_action(request):
         shift.save()
 
         # Add a success message
-        messages.add_message(request, messages.SUCCESS, _('Your shift has finished!'))
+        messages.add_message(
+            request,
+            messages.SUCCESS,
+            _('Your shift has finished!')
+        )
 
     # Toggle pause on current shift
     elif '_pause' in request.POST:
@@ -133,7 +152,11 @@ class ShiftManualCreate(CreateView):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
-        return super(ShiftManualCreate, self).dispatch(request, *args, **kwargs)
+        return super(ShiftManualCreate, self).dispatch(
+                                                        request,
+                                                        *args,
+                                                        **kwargs
+                                                        )
 
     def get_initial(self):
         """
@@ -208,7 +231,11 @@ class ShiftManualDelete(DeleteView):
         if object.employee != self.request.user:
             raise Http404(_('404 - Shift not found!'))
 
-        return super(ShiftManualDelete, self).dispatch(request, *args, **kwargs)
+        return super(ShiftManualDelete, self).dispatch(
+                                                        request,
+                                                        *args,
+                                                        **kwargs
+                                                        )
 
     def get_object(self):
         # it doesn't matter how many times get_object is called per request


### PR DESCRIPTION
If the user doesn't define a contract by himself, he may use the default "None-contract" to clock his shifts.