### PR TITLE
Pause field now editable, changes will be accounted for

### DIFF
--- a/clock/work/forms.py
+++ b/clock/work/forms.py
@@ -68,7 +68,7 @@ class ContractForm(forms.ModelForm):
 class ShiftForm(forms.ModelForm):
     class Meta:
         model = Shift
-        fields = ('shift_started', 'contract', 'shift_finished', 'note',)
+        fields = ('shift_started', 'shift_finished', 'pause_duration', 'contract', 'note',)
         widgets = {
             'shift_started': DateTimePicker(
                 options={

--- a/clock/work/models.py
+++ b/clock/work/models.py
@@ -73,6 +73,8 @@ class Shift(models.Model):
         super(Shift, self).__init__(*args, **kwargs)
         self.__old_shift_started = self.shift_started
         self.__old_shift_finished = self.shift_finished
+        self.__old_pause_duration = self.pause_duration
+        self.__old_shift_duration = self.shift_duration
 
     def clean(self, *args, **kwargs):
         """
@@ -90,9 +92,10 @@ class Shift(models.Model):
         or dashboard-frontend.
         """
         if self.shift_finished != self.__old_shift_finished \
-            or self.shift_started != self.__old_shift_started:
-                self.shift_duration = (self.shift_finished -
-                self.shift_started) - self.pause_duration
+           or self.shift_started != self.__old_shift_started \
+           or self.pause_duration != self.__old_pause_duration:
+               self.shift_duration = (self.shift_finished -
+               self.shift_started) - self.pause_duration
         return super(Shift, self).save(*args, **kwargs)
 
     def shift_time_validation(self):


### PR DESCRIPTION
When updating a shift, the pause duration will be shown to the user.
Also when the value for the pause duration is changed, the total work
time will be recalculated.
This DOES NOT check for negative total work time values, as we don't
want to hassle the user. If the user doesn't care, then he'll have
negative work time values in his exported sheet.