### PR TITLE
Changed default DATABASE_URL.

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -118,10 +118,11 @@ MANAGERS = ADMINS
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {
     # Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
-    'default': env.db("DATABASE_URL", default="postgres:///clock"),
+    'default':
+    env.db(
+        "DATABASE_URL", default="postgres://postgres@localhost:5432/postgres"),
 }
 DATABASES['default']['ATOMIC_REQUESTS'] = True
-
 
 # GENERAL CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/dev.yml
+++ b/dev.yml
@@ -13,6 +13,8 @@ services:
       - postgres_backup_dev:/backups
     environment:
       - POSTGRES_USER=clock
+    ports:
+      - "5432:5432"
 
   django:
     build:


### PR DESCRIPTION
Same reason as with GeoMatDigital/django-geomat#73. Quote:

> Now it's possible to start Postgres in a Docker container via
> 
> `docker run --name geomat-postgres -e POSTGRES_USER=postgres -d -p 5432:5432 postgres`
> 
> and afterwards start a local Django server with `python manage.py runserver_plus`, which will use the dockerized Postgres instance.

Furthermore by exposing the default port `5432` inside the `dev.yml` file, we can start postgres with `docker-compose -f dev.yml up postgres` (ref: 0ec5e1e).
