### PR TITLE
Make Django 1.11 work again

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Bleeding edge Django
-django==1.10.3
+django==1.11.2
 
 # Configuration
 django-environ==0.4.3
@@ -31,7 +31,8 @@ pytz==2017.2
 # Your custom requirements go here
 django-bootstrap-breadcrumbs==0.8.2
 django-bootstrap3==8.2.3
-django-bootstrap3-datetimepicker-2==2.4.2
+#django-bootstrap3-datetimepicker-2==2.4.2
+git+git://github.com/blag/django-bootstrap3-datetimepicker.git@f8a78b231b75c331c143d5461456f663827a8af6
 
 reportlab==3.4.0
 lxml==3.8.0


### PR DESCRIPTION
The package `django-bootstrap3-datetimepicker-2` does not work with Django 1.11. Currently there are two unmerged PRs ([PR #65](https://github.com/nkunihiko/django-bootstrap3-datetimepicker/pull/65) and [PR #66](https://github.com/nkunihiko/django-bootstrap3-datetimepicker/pull/66)) that fix the problem. Randomly decided to go with [PR #66](https://github.com/nkunihiko/django-bootstrap3-datetimepicker/pull/66) and specified it in our `base.txt`.

Meanwhile also updated Django to version 1.11.2.