### PR TITLE
Release 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0 (2017-10-22)
+
+* Final 1.0 release. Upcoming releases will introduce breaking changes.
+* Added unit tests for Shifts
+* Fixed several end-user bugs
+
 ## 0.9
 
 * Added ability to add tags to shifts

--- a/README.md
+++ b/README.md
@@ -9,16 +9,6 @@
 Genervt den Stundenzettel für deinen HiWi-Job dauernd per Hand ausfüllen zu müssen? Willst du eine komfortable, mobile und einfache Lösung? Dann ist das Projekt hier genau das richtige.
 Clock erlaubt dem Nutzer seine Arbeitszeit zu stechen, nachträglich hinzuzufügen oder zu editieren.
 
-
-## Nutzung
-
-Folgt.
-
-
-## Zukunft
-
-Im fertigen Produkt soll gerade der Export der eingetragenen Arbeitszeit in ein gewünschtes Dateiformat möglich sein. Dies lässt sich dann beim Arbeitgeber bzw. der Personalabteilung der Goethe-Universität einreichen, um seinen Soll als HiWi zu erfüllen. Für die genaue Thematik siehe: [Mindestlohngesetz](https://de.wikipedia.org/wiki/Mindestlohngesetz_%28Deutschland%29) oder [MiLoG](http://www.gesetze-im-internet.de/milog/).
-
 ## Mitarbeit
 
 Das Projekt ist öffentlich zugänglich und kann deswegen gerne geforked werden. Um es lokal zu nutzen sind allerdings einige Einstellungen zu erledigen.
@@ -26,24 +16,13 @@ Das aktuelle Layout dieser Repository basiert auf [cookiecutter-django](https://
 
 ### Anleitung
 
-
-Hier für muss die aktuelle Version von Docker installiert sein. Am einfachsten erledigt sich das mit der Docker-Engine. Da die Entwicklung auf Windows aktuell (2016-04) noch Probleme bereitet, sollte OS X oder ein anderes UNIX System zur Entwicklung werden.
+Zur Mitarbeit sind `docker` und `docker-compose` notwendig.
 
 #### 1. Develop branch klonen
 
     git clone https://github.com/mimischi/django-clock.git --branch develop
 
-#### 2. Für OS X (nicht nötig auf Linux)
-
-Aktuell muss auf OS X (und Windows) eine extra VM eingerichtet werden, damit Docker läuft. Dazu muss auch [VirtualBox](https://www.virtualbox.org/) installiert sein.
-
-    docker-machine create --driver virtualbox clock
-    
-Danach muss die soeben erstellte Maschine zur aktuell genutzten gesetzt werden:
-
-    eval "$(docker-machine env clock)"
-
-#### 3. System aufbauen & starten
+#### 2. Container bauen und starten
 
     docker-compose -f dev.yml build
     docker-compose -f dev.yml up -d
@@ -52,9 +31,4 @@ Danach muss die soeben erstellte Maschine zur aktuell genutzten gesetzt werden:
 
     docker-compose -f dev.yml run django python manage.py migrate
 
-
-Dazu kann jetzt noch ein Superuser erstellt werden. Grundsätzlich läuft das System jetzt. Unter Linux ist die Seite nun unter localhost:8000 aufrufbar. Unter OS X/Windows führt man folgenden Befehl aus und findet die zugehörige IP heraus:
-
-    docker-machine env clock
-
-Für weitere Hilfe einfach der [offiziellen Anleitung von cookiecutter-django](http://cookiecutter-django.readthedocs.org/en/latest/developing-locally-docker.html) folgen.
+Dazu kann jetzt noch ein Superuser erstellt werden. Grundsätzlich läuft das System jetzt. Unter Linux ist die Seite nun unter localhost:8000 aufrufbar.

--- a/clock/__init__.py
+++ b/clock/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.1.0'
+__version__ = '1.0.0'
 __version_info__ = tuple([
     int(num) if num.isdigit() else num
     for num in __version__.replace('-', '.', 1).split('.')

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,9 @@ exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
 [pep8]
 max-line-length = 120
 exclude=.tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
+
+[yapf]
+based_on_style = pep8
+spaces_before_comment = 4
+split_before_logical_operator = true
+dedent_closing_brackets = false


### PR DESCRIPTION
Finally releasing version 1.0.0.

This version _should_ work without any major problems. Although not the whole code base is covered by unit tests, we've had this version running in production for almost 2 years and got rid of all bugs that end-users encountered.

The upcoming releases will introduce breaking changes.